### PR TITLE
fix: umbrella generator changes

### DIFF
--- a/generator/cli.ts
+++ b/generator/cli.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import {Command, Option} from 'commander';
-import {CHAIN_TO_CHAIN_ID, getDate, getPoolChain, pascalCase} from './common';
+import {CHAIN_TO_CHAIN_ID, generateFolderName, getDate, getPoolChain} from './common';
 import {input, select} from '@inquirer/prompts';
 import {ConfigFile, FEATURE, Options, POOLS, PoolCache, PoolConfigs, PoolIdentifier} from './types';
 import {generateFiles, writeFiles} from './generator';
@@ -160,18 +160,8 @@ if (options.configFile) {
         : POOLS.map((v) => ({name: v, value: v})),
   });
 
-  if (!options.title) {
-    options.title = await input({
-      message: 'Short title of the rewards program:',
-      validate(input) {
-        if (input.length == 0) return "Your title can't be empty";
-        if (input.trim().length > 80) return 'Your title is to long';
-        return true;
-      },
-    });
-  }
-  options.shortName = pascalCase(options.title);
   options.date = getDate();
+  options.shortName = generateFolderName(options);
 
   if (options.feature === FEATURE.SETUP_LM) {
     await fetchLMSetupOptions(options.pool);

--- a/generator/common.ts
+++ b/generator/common.ts
@@ -154,7 +154,8 @@ export function getDate() {
   const years = date.getFullYear();
   const months = date.getMonth() + 1; // it's js so months are 0 indexed
   const day = date.getDate();
-  return `${years}${months <= 9 ? '0' : ''}${months}${day <= 9 ? '0' : ''}${day}`;
+  const time = `${date.getHours()}${date.getMinutes()}${date.getHours()}`;
+  return `${years}${months <= 9 ? '0' : ''}${months}${day <= 9 ? '0' : ''}${day}_${time}`;
 }
 
 /**
@@ -172,7 +173,7 @@ export function generateFolderName(options: Options) {
   } else {
     featureString = '_UmbrellaUpdate';
   }
-  return `${options.date}${featureString}${options.pool}_${options.shortName}`;
+  return `${options.date}${featureString}${options.pool}`;
 }
 
 /**
@@ -190,7 +191,6 @@ export function generateContractName(options: Options, pool?: PoolIdentifier) {
   } else {
     name += 'UmbrellaRewardsUpdate';
   }
-  name += `${options.shortName}`;
   name += `_${options.date}`;
   return name;
 }

--- a/generator/features/__snapshots__/setupLiquidityMining.spec.ts.snap
+++ b/generator/features/__snapshots__/setupLiquidityMining.spec.ts.snap
@@ -34,7 +34,7 @@ export const config: ConfigFile = {
 };
 ",
   "payloadTest": {
-    "contractName": "AaveV3EthereumLido_LMSetupTest_20231023",
+    "contractName": "AaveV3EthereumLido_LMSetup_20231023",
     "payloadTest": "// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
@@ -42,7 +42,7 @@ import {AaveV3EthereumLido, AaveV3EthereumLidoAssets} from 'aave-address-book/Aa
 import {IEmissionManager, ITransferStrategyBase, RewardsDataTypes, IEACAggregatorProxy} from '../../src/interfaces/IEmissionManager.sol';
 import {LMSetupBaseTest} from '../utils/LMSetupBaseTest.sol';
 
-contract AaveV3EthereumLido_LMSetupTest_20231023 is LMSetupBaseTest {
+contract AaveV3EthereumLido_LMSetup_20231023 is LMSetupBaseTest {
   address public constant override REWARD_ASSET =
     AaveV3EthereumLidoAssets.AaveV3EthereumLidoAssets.wstETH_A_TOKEN_UNDERLYING;
   uint88 constant DURATION_DISTRIBUTION = 14 days;

--- a/generator/features/__snapshots__/updateLiquidityMining.spec.ts.snap
+++ b/generator/features/__snapshots__/updateLiquidityMining.spec.ts.snap
@@ -31,7 +31,7 @@ export const config: ConfigFile = {
 };
 ",
   "payloadTest": {
-    "contractName": "AaveV3EthereumLido_LMUpdateTest_20231023",
+    "contractName": "AaveV3EthereumLido_LMUpdate_20231023",
     "payloadTest": "// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
@@ -39,7 +39,7 @@ import {AaveV3EthereumLido, AaveV3EthereumLidoAssets} from 'aave-address-book/Aa
 import {IEmissionManager, ITransferStrategyBase, RewardsDataTypes, IEACAggregatorProxy} from '../../src/interfaces/IEmissionManager.sol';
 import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
 
-contract AaveV3EthereumLido_LMUpdateTest_20231023 is LMUpdateBaseTest {
+contract AaveV3EthereumLido_LMUpdate_20231023 is LMUpdateBaseTest {
   address public constant override REWARD_ASSET = AaveV3EthereumLidoAssets.wstETH_A_TOKEN;
   uint256 public constant override NEW_TOTAL_DISTRIBUTION = 150 * 10 ** 18;
   address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;

--- a/generator/features/__snapshots__/updateUmbrellaRewards.spec.ts.snap
+++ b/generator/features/__snapshots__/updateUmbrellaRewards.spec.ts.snap
@@ -30,7 +30,7 @@ export const config: ConfigFile = {
 };
 ",
   "payloadTest": {
-    "contractName": "AaveV3BaseSepolia_UmbrellaRewardsUpdateTest_20250602",
+    "contractName": "AaveV3BaseSepolia_UmbrellaRewardsUpdate_20250602",
     "payloadTest": "// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
@@ -40,9 +40,9 @@ import {UmbrellaBaseSepoliaAssets} from 'aave-address-book/UmbrellaBaseSepolia.s
 import {UmbrellaRewardsBaseTest} from '../utils/UmbrellaRewardsBaseTest.sol';
 
 /**
- * emit calldata: forge test --mp tests/20250602_UmbrellaUpdateAaveV3BaseSepolia_Test/AaveV3BaseSepolia_UmbrellaRewardsUpdateTest_20250602.t.sol -vv
+ * emit calldata: forge test --mp tests/20250602_UmbrellaUpdateAaveV3BaseSepolia/AaveV3BaseSepolia_UmbrellaRewardsUpdate_20250602.t.sol -vv
  */
-contract AaveV3BaseSepolia_UmbrellaRewardsUpdateTest_20250602 is
+contract AaveV3BaseSepolia_UmbrellaRewardsUpdate_20250602 is
   UmbrellaRewardsBaseTest,
   UmbrellaBaseSepoliaConfig
 {

--- a/generator/features/updateUmbrellaRewards.ts
+++ b/generator/features/updateUmbrellaRewards.ts
@@ -31,16 +31,7 @@ export async function fetchUmbrellaRewardsUpdateParams({pool}): Promise<Umbrella
     pool,
     required: true,
   });
-  let assetAddress: Hex;
-  if (asset == 'custom') {
-    asset = await addressPrompt({
-      message: 'Enter the address of the umbrella asset manually:',
-      required: true,
-    });
-    assetAddress = asset as Hex;
-  } else {
-    assetAddress = addressBook[umbrella].UMBRELLA_STAKE_ASSETS[asset].STAKE_TOKEN;
-  }
+  const assetAddress = addressBook[umbrella].UMBRELLA_STAKE_ASSETS[asset].STAKE_TOKEN;
 
   const rewardsControllerContract = getContract({
     abi: IUmbrellaRewardsController_ABI,
@@ -96,15 +87,11 @@ export async function fetchUmbrellaRewardsUpdateParams({pool}): Promise<Umbrella
     let maxEmissionsPerSecond: string;
     if (maxEmissionsPerSecondChoice == 'units') {
       const tokenUnits = await numberPrompt({
-        message: 'Enter the token units for maxEmissionsPerSecond',
-        required: true,
-      });
-      const days = await numberPromptInDays({
-        message: 'Enter the days for maxEmissionsPerSecond:',
+        message: 'Enter the token units for maxEmissionsPerSecond per 180 days',
         required: true,
       });
       const tokenDecimals = await getTokenDecimals(reward.asset, chainId);
-      maxEmissionsPerSecond = `uint256(${tokenUnits} * 1e${tokenDecimals}) / ${days} days`;
+      maxEmissionsPerSecond = `uint256(${tokenUnits} * 1e${tokenDecimals}) / 180 days`;
     } else if (maxEmissionsPerSecondChoice == 'raw') {
       maxEmissionsPerSecond = await numberPromptNoTransform(
         {message: 'Enter the maxEmissionsPerSecond raw value', required: true},

--- a/generator/features/updateUmbrellaRewards.ts
+++ b/generator/features/updateUmbrellaRewards.ts
@@ -79,7 +79,7 @@ export async function fetchUmbrellaRewardsUpdateParams({pool}): Promise<Umbrella
       message: `Please input the maxEmissionsPerSecond you want to configure for the reward: ${reward.symbol} and asset: ${asset}`,
       choices: [
         {name: 'Keep maxEmissionsPerSecond the same as current', value: 'current'},
-        {name: 'Enter maxEmissionsPerSecond in token units / days', value: 'units'},
+        {name: 'Enter maxEmissionsPerSecond in token units / 180 days', value: 'units'},
         {name: 'Enter raw maxEmissionsPerSecond', value: 'raw'},
       ],
     });
@@ -129,20 +129,8 @@ export async function fetchUmbrellaRewardsUpdateParams({pool}): Promise<Umbrella
     } else {
       distributionEnd = 'EngineFlags.KEEP_CURRENT';
     }
-
-    let rewardPayer = await select({
-      message: 'Enter the address of the rewards payer you want to configure',
-      choices: [
-        {name: 'Aave Collector (Default)', value: getDefaultCollector(pool)},
-        {name: 'Custom Address (Enter Manually)', value: 'custom'},
-      ],
-    });
-    if (rewardPayer == 'custom') {
-      rewardPayer = await addressPrompt({
-        message: 'Enter the address of the new rewards payer you want to configure:',
-        required: true,
-      });
-    }
+    // default rewardPayer to the collector
+    const rewardPayer = getDefaultCollector(pool);
 
     input.push({
       asset,

--- a/generator/prompts/assetsSelectPrompt.ts
+++ b/generator/prompts/assetsSelectPrompt.ts
@@ -53,7 +53,6 @@ export async function umbrellaStkAssetsSelectPrompt({pool, message}: GenericPool
   return await select({
     message,
     choices: [
-      {name: 'Custom Address (Enter Manually)', value: 'custom'},
       ...getUmbrellaStkAssets(pool).map((asset) => ({name: asset, value: asset})),
     ],
   });

--- a/generator/types.ts
+++ b/generator/types.ts
@@ -37,7 +37,7 @@ export interface Options {
   force?: boolean;
   feature: FEATURE;
   pool: PoolIdentifier;
-  title: string;
+  title?: string;
   shortName: string;
   configFile?: string;
   date: string;


### PR DESCRIPTION
### Changelog:

- Removes input of `rewardsPayer` from user on the cli generator
- Removes input of custom umbrella stake token address, and default the selection from the address-book only
- Removes the input of title from user on the cli generator 
- Added logging the percent change on the foundry tests for `maxEmissionsPerSecond`
- Added logging the distributionEnd in readable format on the foundry tests.
- For inputting the `maxEmissionsPerSecond` via token unit format, we now only ask the user to input `maxEmissionsPerSecond` in token units per 180 days always, and not in token units and days both to reduce any chances of error via user.