### PR TITLE
✨ Renew USDS lm 36

### DIFF
--- a/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
+++ b/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
@@ -7,7 +7,7 @@ import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
 
 contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
   address public constant override REWARD_ASSET = AaveV3EthereumAssets.USDS_A_TOKEN;
-  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 141177 * 10 ** 18;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 126639 * 10 ** 18;
   address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
   address public constant override EMISSION_MANAGER = AaveV3Ethereum.EMISSION_MANAGER;
   uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;
@@ -17,7 +17,7 @@ contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
     AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 22573562);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 22622751);
   }
 
   function test_claimRewards() public {

--- a/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
+++ b/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
@@ -7,7 +7,7 @@ import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
 
 contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
   address public constant override REWARD_ASSET = AaveV3EthereumAssets.USDS_A_TOKEN;
-  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 310902 * 10 ** 18;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 311140 * 10 ** 18;
   address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
   address public constant override EMISSION_MANAGER = AaveV3Ethereum.EMISSION_MANAGER;
   uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;
@@ -17,7 +17,7 @@ contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
     AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 22268431);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 22323361);
   }
 
   function test_claimRewards() public {

--- a/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
+++ b/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
@@ -7,7 +7,7 @@ import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
 
 contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
   address public constant override REWARD_ASSET = AaveV3EthereumAssets.USDS_A_TOKEN;
-  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 350419 * 10 ** 18;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 310902 * 10 ** 18;
   address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
   address public constant override EMISSION_MANAGER = AaveV3Ethereum.EMISSION_MANAGER;
   uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;

--- a/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
+++ b/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
@@ -7,7 +7,7 @@ import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
 
 contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
   address public constant override REWARD_ASSET = AaveV3EthereumAssets.USDS_A_TOKEN;
-  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 237526 * 10 ** 18;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 202851 * 10 ** 18;
   address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
   address public constant override EMISSION_MANAGER = AaveV3Ethereum.EMISSION_MANAGER;
   uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;
@@ -17,7 +17,7 @@ contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
     AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 22468716);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 22523120);
   }
 
   function test_claimRewards() public {

--- a/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
+++ b/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
@@ -7,7 +7,7 @@ import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
 
 contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
   address public constant override REWARD_ASSET = AaveV3EthereumAssets.USDS_A_TOKEN;
-  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 486306 * 10 ** 18;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 464575 * 10 ** 18;
   address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
   address public constant override EMISSION_MANAGER = AaveV3Ethereum.EMISSION_MANAGER;
   uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;
@@ -17,7 +17,7 @@ contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
     AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 22023529);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 22067905);
   }
 
   function test_claimRewards() public {

--- a/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
+++ b/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
@@ -7,7 +7,7 @@ import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
 
 contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
   address public constant override REWARD_ASSET = AaveV3EthereumAssets.USDS_A_TOKEN;
-  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 202851 * 10 ** 18;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 141177 * 10 ** 18;
   address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
   address public constant override EMISSION_MANAGER = AaveV3Ethereum.EMISSION_MANAGER;
   uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;
@@ -17,7 +17,7 @@ contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
     AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 22523120);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 22573562);
   }
 
   function test_claimRewards() public {

--- a/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
+++ b/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
@@ -7,7 +7,7 @@ import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
 
 contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
   address public constant override REWARD_ASSET = AaveV3EthereumAssets.USDS_A_TOKEN;
-  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 311140 * 10 ** 18;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 289635 * 10 ** 18;
   address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
   address public constant override EMISSION_MANAGER = AaveV3Ethereum.EMISSION_MANAGER;
   uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;
@@ -17,7 +17,7 @@ contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
     AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 22323361);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 22374735);
   }
 
   function test_claimRewards() public {

--- a/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
+++ b/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
@@ -7,17 +7,17 @@ import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
 
 contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
   address public constant override REWARD_ASSET = AaveV3EthereumAssets.USDS_A_TOKEN;
-  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 337362 * 10 ** 18;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 350419 * 10 ** 18;
   address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
   address public constant override EMISSION_MANAGER = AaveV3Ethereum.EMISSION_MANAGER;
   uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;
-  address public constant aUSDS_WHALE = 0x65AE0ed283fA71fd0d22f13512d7e0BD9E54c14A;
+  address public constant aUSDS_WHALE = 0x3290b7E095E756EE0fa9f51c4087C9F6546eE4fB;
 
   address public constant override DEFAULT_INCENTIVES_CONTROLLER =
     AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 22167670);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 22223973);
   }
 
   function test_claimRewards() public {
@@ -40,7 +40,7 @@ contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
       aUSDS_WHALE,
       AaveV3EthereumAssets.USDS_A_TOKEN,
       NEW_DURATION_DISTRIBUTION_END,
-      7896.46 * 10 ** 18
+      3819.5671 * 10 ** 18
     );
   }
 

--- a/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
+++ b/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
@@ -7,7 +7,7 @@ import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
 
 contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
   address public constant override REWARD_ASSET = AaveV3EthereumAssets.USDS_A_TOKEN;
-  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 291248 * 10 ** 18;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 237526 * 10 ** 18;
   address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
   address public constant override EMISSION_MANAGER = AaveV3Ethereum.EMISSION_MANAGER;
   uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;
@@ -17,7 +17,7 @@ contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
     AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 22423849);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 22468716);
   }
 
   function test_claimRewards() public {

--- a/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
+++ b/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
@@ -7,7 +7,7 @@ import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
 
 contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
   address public constant override REWARD_ASSET = AaveV3EthereumAssets.USDS_A_TOKEN;
-  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 464575 * 10 ** 18;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 458911 * 10 ** 18;
   address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
   address public constant override EMISSION_MANAGER = AaveV3Ethereum.EMISSION_MANAGER;
   uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;
@@ -17,7 +17,7 @@ contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
     AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 22067905);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 22115914);
   }
 
   function test_claimRewards() public {

--- a/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
+++ b/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
@@ -7,7 +7,7 @@ import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
 
 contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
   address public constant override REWARD_ASSET = AaveV3EthereumAssets.USDS_A_TOKEN;
-  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 289635 * 10 ** 18;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 291248 * 10 ** 18;
   address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
   address public constant override EMISSION_MANAGER = AaveV3Ethereum.EMISSION_MANAGER;
   uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;
@@ -17,7 +17,7 @@ contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
     AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 22374735);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 22423849);
   }
 
   function test_claimRewards() public {

--- a/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
+++ b/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
@@ -7,7 +7,7 @@ import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
 
 contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
   address public constant override REWARD_ASSET = AaveV3EthereumAssets.USDS_A_TOKEN;
-  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 458911 * 10 ** 18;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 337362 * 10 ** 18;
   address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
   address public constant override EMISSION_MANAGER = AaveV3Ethereum.EMISSION_MANAGER;
   uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;
@@ -17,7 +17,7 @@ contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
     AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 22115914);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 22167670);
   }
 
   function test_claimRewards() public {

--- a/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
+++ b/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
@@ -40,7 +40,7 @@ contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
       aUSDS_WHALE,
       AaveV3EthereumAssets.USDS_A_TOKEN,
       NEW_DURATION_DISTRIBUTION_END,
-      3819.5671 * 10 ** 18
+      5300 * 10 ** 18
     );
   }
 

--- a/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
+++ b/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
@@ -17,7 +17,7 @@ contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
     AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 22223973);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 22268431);
   }
 
   function test_claimRewards() public {

--- a/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
+++ b/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {IEmissionManager, ITransferStrategyBase, RewardsDataTypes, IEACAggregatorProxy, IRewardsController} from '../../src/interfaces/IEmissionManager.sol';
+import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
+
+contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
+  address public constant override REWARD_ASSET = AaveV3EthereumAssets.USDS_A_TOKEN;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 486306 * 10 ** 18;
+  address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
+  address public constant override EMISSION_MANAGER = AaveV3Ethereum.EMISSION_MANAGER;
+  uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;
+  address public constant aUSDS_WHALE = 0x65AE0ed283fA71fd0d22f13512d7e0BD9E54c14A;
+
+  address public constant override DEFAULT_INCENTIVES_CONTROLLER =
+    AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 22023529);
+  }
+
+  function test_claimRewards() public {
+    NewEmissionPerAsset memory newEmissionPerAsset = _getNewEmissionPerSecond();
+    NewDistributionEndPerAsset memory newDistributionEndPerAsset = _getNewDistributionEnd();
+
+    vm.startPrank(EMISSION_ADMIN);
+    IEmissionManager(AaveV3Ethereum.EMISSION_MANAGER).setEmissionPerSecond(
+      newEmissionPerAsset.asset,
+      newEmissionPerAsset.rewards,
+      newEmissionPerAsset.newEmissionsPerSecond
+    );
+    IEmissionManager(AaveV3Ethereum.EMISSION_MANAGER).setDistributionEnd(
+      newDistributionEndPerAsset.asset,
+      newDistributionEndPerAsset.reward,
+      newDistributionEndPerAsset.newDistributionEnd
+    );
+
+    _testClaimRewardsForWhale(
+      aUSDS_WHALE,
+      AaveV3EthereumAssets.USDS_A_TOKEN,
+      NEW_DURATION_DISTRIBUTION_END,
+      7896.46 * 10 ** 18
+    );
+  }
+
+  function _getNewEmissionPerSecond() internal pure override returns (NewEmissionPerAsset memory) {
+    NewEmissionPerAsset memory newEmissionPerAsset;
+
+    address[] memory rewards = new address[](1);
+    rewards[0] = REWARD_ASSET;
+    uint88[] memory newEmissionsPerSecond = new uint88[](1);
+    newEmissionsPerSecond[0] = _toUint88(NEW_TOTAL_DISTRIBUTION / NEW_DURATION_DISTRIBUTION_END);
+
+    newEmissionPerAsset.asset = AaveV3EthereumAssets.USDS_A_TOKEN;
+    newEmissionPerAsset.rewards = rewards;
+    newEmissionPerAsset.newEmissionsPerSecond = newEmissionsPerSecond;
+
+    return newEmissionPerAsset;
+  }
+
+  function _getNewDistributionEnd()
+    internal
+    view
+    override
+    returns (NewDistributionEndPerAsset memory)
+  {
+    NewDistributionEndPerAsset memory newDistributionEndPerAsset;
+
+    newDistributionEndPerAsset.asset = AaveV3EthereumAssets.USDS_A_TOKEN;
+    newDistributionEndPerAsset.reward = REWARD_ASSET;
+    newDistributionEndPerAsset.newDistributionEnd = _toUint32(
+      IRewardsController(AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER).getDistributionEnd(
+        newDistributionEndPerAsset.asset,
+        newDistributionEndPerAsset.reward
+      ) + NEW_DURATION_DISTRIBUTION_END
+    );
+
+    return newDistributionEndPerAsset;
+  }
+}

--- a/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
+++ b/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250211.t.sol
@@ -7,7 +7,7 @@ import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
 
 contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
   address public constant override REWARD_ASSET = AaveV3EthereumAssets.USDS_A_TOKEN;
-  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 126639 * 10 ** 18;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 41356 * 10 ** 18;
   address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
   address public constant override EMISSION_MANAGER = AaveV3Ethereum.EMISSION_MANAGER;
   uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;
@@ -17,7 +17,7 @@ contract AaveV3Ethereum_LMUpdateRenewUSDSLM18_20250217 is LMUpdateBaseTest {
     AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 22622751);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 22718389);
   }
 
   function test_claimRewards() public {

--- a/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/config.ts
+++ b/tests/20250217_LMUpdateAaveV3Ethereum_RenewUSDSLM18/config.ts
@@ -1,0 +1,27 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    feature: 'UPDATE_LM',
+    pool: 'AaveV3Ethereum',
+    title: 'Renew USDS LM 18',
+    shortName: 'RenewUSDSLM18',
+    date: '20250211',
+  },
+  poolOptions: {
+    AaveV3Ethereum: {
+      configs: {
+        UPDATE_LM: {
+          emissionsAdmin: '0xac140648435d03f784879cd789130F22Ef588Fcd',
+          rewardToken: 'AaveV3EthereumAssets.USDS_A_TOKEN',
+          rewardTokenDecimals: 18,
+          asset: 'USDS_aToken',
+          distributionEnd: '7',
+          rewardAmount: '768318',
+          whaleAddress: '0x65AE0ed283fA71fd0d22f13512d7e0BD9E54c14A',
+          whaleExpectedReward: '7896.46',
+        },
+      },
+      cache: {blockNumber: 21819446},
+    },
+  },
+};


### PR DESCRIPTION
## Recap 
- Renew Ethereum aUSDS LM
- Config:
  - asset rewarded:
    - aUSDS
  - reward asset:
    - aUSDS 
  - duration: 7 days
  - new emission: 41,356 USDS (https://etherscan.io/tx/0x9083b37a5f89b17852d3837017442c7dcd993fe0dfe89743ef103ac1130a47f9)

## Simulation on Tenderly (Safe batch)

https://dashboard.tenderly.co/public/safe/safe-apps/simulator/419c361d-8522-43f6-8019-ebfe315ae101/logs

## Calldatas

- `newDistributionEnd`
  - ```0xc5a7b53800000000000000000000000032a6268f9ba3642dda7892add74f1d34469a425900000000000000000000000032a6268f9ba3642dda7892add74f1d34469a425900000000000000000000000000000000000000000000000000000000685bd6b0```

- `newEmissionPerSecond `
  - ```0xf996868b00000000000000000000000032a6268f9ba3642dda7892add74f1d34469a4259000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000100000000000000000000000032a6268f9ba3642dda7892add74f1d34469a4259000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000f2eee92df264bd```